### PR TITLE
[add] join game + signalr provider

### DIFF
--- a/frontend/tic-tac-toe/src/contexts/signalr-provider.tsx
+++ b/frontend/tic-tac-toe/src/contexts/signalr-provider.tsx
@@ -1,0 +1,107 @@
+import React, { createContext, useEffect, useRef } from "react";
+import { HubConnectionBuilder, HubConnection, HubConnectionState } from "@microsoft/signalr";
+
+// Типы для соединения
+interface JoinRoomConnection {
+    Player: string;
+    RoomId: string;
+}
+
+export interface SignalRContextProps {
+    connectionRef: React.RefObject<HubConnection | null>;
+    createOrJoinRoom: (userId: string, roomId: string | null, maxScore?: number) => Promise<void>;
+    joinRoom: (userId: string, roomId: string) => Promise<void>;
+    joinGame: (userId: string, roomId: string) => Promise<void>;
+}
+
+export const SignalRContext = createContext<SignalRContextProps | undefined>(undefined);
+
+export const SignalRProvider:React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const connectionRef = useRef<HubConnection | null>(null);
+
+    const startConnection = async () => {
+        if (connectionRef.current && connectionRef.current.state === HubConnectionState.Connected) {
+            console.log("Уже подключен к серверу");
+            return;
+        }
+
+        const newConnection = new HubConnectionBuilder()
+            .withUrl("http://localhost:8080/gameHub")
+            .build();
+
+        connectionRef.current = newConnection;
+
+        newConnection.on("Info", (data) => {
+            console.log("Info:", data);
+        });
+
+        try {
+            await newConnection.start();
+            console.log("Подключение установлено");
+        } catch (error) {
+            console.error("Ошибка подключения:", error);
+            setTimeout(startConnection, 5000);
+        }
+    };
+
+    const createOrJoinRoom = async (userId: string, roomId: string | null, maxScore?: number) => {
+        if (!connectionRef.current || connectionRef.current.state !== HubConnectionState.Connected) {
+            console.error("Нет соединения с сервером");
+            return;
+        }
+
+        const connection: { Player1: string; RoomId: string | null; MaxScore?: number } = { Player1: userId, RoomId: roomId, MaxScore: maxScore };
+        try {
+            const roomIdReturned = await connectionRef.current.invoke("CreateOrJoinRoom", connection);
+            console.log("room: " + roomIdReturned);
+        } catch (error) {
+            console.error("Ошибка при входе в комнату:", error);
+        }
+    };
+
+    const joinRoom = async (userId: string, roomId: string) => {
+        if (!connectionRef.current || connectionRef.current.state !== HubConnectionState.Connected) {
+            console.error("Нет соединения с сервером");
+            return;
+        }
+
+        const connection: JoinRoomConnection = { Player: userId, RoomId: roomId };
+        try {
+            const roomIdReturned = await connectionRef.current.invoke("JoinRoom", connection);
+            console.log("Ответ от сервера:", roomIdReturned);
+        } catch (error) {
+            console.error("Ошибка при входе в комнату:", error);
+        }
+    };
+
+    const joinGame = async (userId: string, roomId: string) => {
+        if (!connectionRef.current || connectionRef.current.state !== HubConnectionState.Connected) {
+            console.error("Нет соединения с сервером");
+            return;
+        }
+
+        const connection: JoinRoomConnection = { Player: userId, RoomId: roomId };
+        console.log(connection);
+
+        try {
+            const roomIdReturned = await connectionRef.current.invoke("JoinGame", connection);
+            console.log("Ответ от сервера:", roomIdReturned);
+        } catch (error) {
+            console.error("Ошибка при входе в комнату:", error);
+        }
+    };
+
+    useEffect(() => {
+        startConnection();
+
+        return () => {
+            connectionRef.current?.stop();
+        };
+    }, []);
+
+    return (
+        <SignalRContext.Provider value={{ connectionRef, createOrJoinRoom, joinRoom, joinGame }}>
+            {children}
+        </SignalRContext.Provider>
+    );
+};

--- a/frontend/tic-tac-toe/src/hooks/use-signalr.ts
+++ b/frontend/tic-tac-toe/src/hooks/use-signalr.ts
@@ -1,99 +1,10 @@
-import React, { useRef, useEffect } from "react";
-import { HubConnectionBuilder, HubConnection, HubConnectionState } from "@microsoft/signalr";
+import {useContext} from "react";
+import {SignalRContext, SignalRContextProps} from "../contexts/signalr-provider.tsx";
 
-interface GameConnection {
-    Player1: string;
-    RoomId: string | null;
-    MaxScore?: number;
-}
-
-interface JoinRoomConnection {
-    Player: string;
-    RoomId: string;
-}
-
-interface useSignalRProps {
-    setRoomId: React.Dispatch<React.SetStateAction<string | null>>;
-    setGameStatus: React.Dispatch<React.SetStateAction<string>>;
-    setMove: React.Dispatch<React.SetStateAction<number>>;
-}
-
-export const useSignalR = ({ setRoomId }: useSignalRProps) => {
-    const connectionRef = useRef<HubConnection | null>(null);
-
-    const startConnection = async () => {
-        if (connectionRef.current && connectionRef.current.state === HubConnectionState.Connected) {
-            console.log("Уже подключен к серверу");
-            return;
-        }
-
-        const newConnection = new HubConnectionBuilder()
-            .withUrl("http://localhost:5026/gameHub")
-            .build();
-
-        connectionRef.current = newConnection;
-
-        newConnection.on("Info", (data) => {
-            console.log("Info:", data);
-        });
-
-        try {
-            await newConnection.start();
-            console.log("Подключение установлено");
-        } catch (error) {
-            console.error("Ошибка подключения:", error);
-            setTimeout(startConnection, 5000);
-        }
-    };
-
-    const createOrJoinRoom = async (userId: string, roomId: string | null, maxScore?: number) => {
-        if (!connectionRef.current || connectionRef.current.state !== HubConnectionState.Connected) {
-            console.error("Нет соединения с сервером");
-            return;
-        }
-
-        const connection: GameConnection = { Player1: userId, RoomId: roomId, MaxScore: maxScore };
-        console.log(connection);
-        try {
-            const roomIdReturned = await connectionRef.current.invoke("CreateOrJoinRoom", connection);
-            setRoomId(roomIdReturned);
-            console.log("room: " + roomIdReturned)
-        } catch (error) {
-            console.error("Ошибка при входе в комнату:", error);
-        }
-    };
-
-
-    const joinRoom = async (userId: string, roomId: string) => {
-        if (!connectionRef.current || connectionRef.current.state !== HubConnectionState.Connected) {
-            console.error("Нет соединения с сервером");
-            return;
-        }
-
-        const connection: JoinRoomConnection = { Player: userId, RoomId: roomId };
-
-        console.log("Отправляем объект в JoinRoom:", JSON.stringify(connection));
-
-        try {
-            const roomIdReturned = await connectionRef.current.invoke("JoinRoom", connection);
-            console.log("Ответ от сервера:", roomIdReturned);
-        } catch (error) {
-            console.error("Ошибка при входе в комнату:", error);
-        }
-    };
-
-
-    useEffect(() => {
-        startConnection();
-
-        return () => {
-            connectionRef.current?.stop();
-        };
-    }, []);
-
-    return {
-        createOrJoinRoom,
-        joinRoom,
-        connectionRef,
-    };
+export const useSignalR = (): SignalRContextProps => {
+    const context = useContext(SignalRContext);
+    if (!context) {
+        throw new Error("useSignalR must be used within a SignalRProvider");
+    }
+    return context;
 };

--- a/frontend/tic-tac-toe/src/main.tsx
+++ b/frontend/tic-tac-toe/src/main.tsx
@@ -15,6 +15,8 @@ import {jwtDecode} from "jwt-decode";
 import {JWTTokenDecoded} from "./interfaces/jwt-token/jwt-decoded.ts";
 import {useUserActions} from "./hooks/use-actions.ts";
 import {useUserTypedSelector} from "./hooks/use-typed-selector.ts";
+import {SignalRProvider} from "./contexts/signalr-provider.tsx";
+import {useSignalR} from "./hooks/use-signalr.ts";
 
 const ProtectedRoute = ({ element }: { element: JSX.Element }) => {
     const { id } = useUserTypedSelector(state => state.user);
@@ -30,6 +32,7 @@ export const App = () => {
     const { alerts, removeAlert } = useAlerts();
     const {createUserFromToken} = useUserActions();
     const [isAuthChecked, setIsAuthChecked] = useState(false);
+    const {joinGame} = useSignalR()
 
     useEffect(() => {
         const authCookie = document.cookie.split('; ').find((row) => row.startsWith('jwt='));
@@ -67,7 +70,7 @@ export const App = () => {
             <Routes>
                 <Route path={"/sign-in"} element={<SignIn />} />
                 <Route path={"/sign-up"} element={<SignUp />} />
-                <Route path="/game/:id" element={<ProtectedRoute element={<Game />} />} />
+                <Route path="/game/:roomId" element={<ProtectedRoute element={<Game joinGame={joinGame} />} />} />
                 <Route path="/" element={<ProtectedRoute element={<Main />} />} />
             </Routes>
         </>
@@ -76,10 +79,12 @@ export const App = () => {
 
 createRoot(document.getElementById('root')!).render(
     <Provider store={store}>
-        <AlertProvider>
-            <BrowserRouter>
-                <App />
-            </BrowserRouter>
-        </AlertProvider>
+        <SignalRProvider>
+            <AlertProvider>
+                <BrowserRouter>
+                    <App />
+                </BrowserRouter>
+            </AlertProvider>
+        </SignalRProvider>
     </Provider>
 )

--- a/frontend/tic-tac-toe/src/pages/game/index.tsx
+++ b/frontend/tic-tac-toe/src/pages/game/index.tsx
@@ -1,6 +1,11 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import {useUserTypedSelector} from "../../hooks/use-typed-selector.ts";
+import {useParams} from "react-router-dom";
 
-const Game: React.FC = () => {
+const Game = (props: { joinGame: (userId: string, roomId: string) => Promise<void> }) => {
+    const {joinGame} = props;
+    const {id} = useUserTypedSelector(state => state.user);
+    const {roomId} = useParams<string>();
     const [board, setBoard] = useState<Array<string | null>>(Array(9).fill(null));
     const [isXNext, setIsXNext] = useState(true);
     const [winningLine, setWinningLine] = useState<number[] | null>(null);
@@ -45,6 +50,7 @@ const Game: React.FC = () => {
 
     return (
         <div className="game">
+            <button className={"main-button"} onClick={() => joinGame(id, roomId!)}>Присоединиться</button>
             <div className="players">
                 {players.map(player => (
                     <div key={player.symbol} className="player">

--- a/frontend/tic-tac-toe/src/pages/main/index.tsx
+++ b/frontend/tic-tac-toe/src/pages/main/index.tsx
@@ -19,18 +19,9 @@ const Main: React.FC = () => {
     const navigate = useNavigate();
     const componentRef = useRef<HTMLDivElement | null>(null);
     const {id, score, username} = useUserTypedSelector(state => state.user);
-    const [roomId, setRoomId] = useState<string | null>(null);
-    const [gameStatus, setGameStatus] = useState<string>("waiting");
-    const [move, setMove] = useState<number>(0);
     const {deleteUser} = useUserActions();
-    console.log("user: " + id)
-    console.log(gameStatus, move)
 
-    const { createOrJoinRoom, joinRoom } = useSignalR({
-        setRoomId,
-        setGameStatus,
-        setMove,
-    });
+    const { createOrJoinRoom, joinRoom } = useSignalR();
 
     const handleScroll = useCallback((event: Event) => {
         const target = event.target as Document;
@@ -100,11 +91,11 @@ const Main: React.FC = () => {
         }
     };
 
-    const handleGameJoin = (gameId: string) => {
-        //navigate(`/game/${gameId}`);
-
-        joinRoom(id, gameId)
+    const handleGameJoin = async (gameId: string) => {
+        await joinRoom(id, gameId)
             .then(r => console.log(r))
+
+        navigate(`/game/${gameId}`);
     }
 
     return (
@@ -141,7 +132,7 @@ const Main: React.FC = () => {
                 <div className="modal">
                     <h2>Создать игру</h2>
                     <input type="number" value={maxRating} onChange={e => setMaxRating(parseInt(e.target.value))} placeholder="Макс. рейтинг" />
-                    <button onClick={() => createOrJoinRoom(id, roomId, maxRating)}>Создать</button>
+                    <button onClick={() => createOrJoinRoom(id, null, maxRating)}>Создать</button>
                 </div>
             )}
         </div>

--- a/frontend/tic-tac-toe/src/utils/api-client.ts
+++ b/frontend/tic-tac-toe/src/utils/api-client.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 // Axios-клиент для запросов к API
 const apiClient = axios.create({
-  baseURL: 'http://localhost:5026/',
+  baseURL: 'http://localhost:8080/',
 });
 
 export default apiClient;


### PR DESCRIPTION
- Добавил signalr provider для создания единственного контекста для всего приложения, при вызове хука useSignalR каждый раз регистрировалось новое подключение, поэтому приходилось вызывать хук единожды во всем приложении, что было крайне неудобно, приходилось тащить зависимости через несколько компонентов.
- Добавил метод для SignalR `joinGame` для попытки пользователя войти в саму игру в качестве участника, а не зрителя.